### PR TITLE
🎨 Palette: Add loading state to Button component

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
+import { Loader2 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
@@ -41,10 +42,13 @@ function Button({
   variant,
   size,
   asChild = false,
+  isLoading = false,
+  children,
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
+    isLoading?: boolean
   }) {
   const Comp = asChild ? Slot : "button"
 
@@ -52,8 +56,19 @@ function Button({
     <Comp
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
+      disabled={isLoading || props.disabled}
+      aria-busy={isLoading ? "true" : undefined}
       {...props}
-    />
+    >
+      {isLoading && !asChild ? (
+        <>
+          <Loader2 className="animate-spin" />
+          {children}
+        </>
+      ) : (
+        children
+      )}
+    </Comp>
   )
 }
 


### PR DESCRIPTION
🎨 **Palette Improvement: Button Loading State**

Added a standardized loading state to the shared `Button` component to improve user feedback during async operations.

**Changes:**
- Added `isLoading` prop to `Button` component.
- Implements `Loader2` spinner from `lucide-react`.
- Handles `aria-busy` and `disabled` states automatically.
- Respects `asChild` usage (skips spinner injection to avoid slot errors).

**Verification:**
- Verified via temporary test page with various button variants.
- Ran `pnpm build` to ensure type safety.
- Ran `pnpm lint` and `pnpm test:unit` to ensure no regressions.
- Screenshot verification confirmed correct rendering.

**Note:**
- Observed that `destructive` variant styling seems to be missing definitions for `bg-destructive`, causing visibility issues for that specific variant, but this is a pre-existing issue unrelated to the loading state logic.

---
*PR created automatically by Jules for task [13528040103024483283](https://jules.google.com/task/13528040103024483283) started by @carlsuburbmates*