### PR TITLE
🎨 Palette: Add ARIA label to search clear button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-02 - Icon-Only Button Accessibility
+**Learning:** Icon-only buttons used for input manipulation (like the clear search 'X' button in `DirectorySearch.tsx`) need an explicit `aria-label` to communicate their function to screen readers, and the decorative SVG icons within should be hidden with `aria-hidden="true"` to prevent redundant announcements.
+**Action:** Always ensure that any button without visible text content has a descriptive `aria-label` and that its internal icon is marked with `aria-hidden="true"`.

--- a/src/components/regions/DirectorySearch.tsx
+++ b/src/components/regions/DirectorySearch.tsx
@@ -48,8 +48,9 @@ export function DirectorySearch({ initialSearch = '' }: DirectorySearchProps) {
               type="button"
               onClick={() => setSearch('')}
               className="absolute right-4 p-1 hover:bg-slate-100 transition-colors"
+              aria-label="Clear search"
             >
-              <X className="h-4 w-4 text-black" />
+              <X className="h-4 w-4 text-black" aria-hidden="true" />
             </button>
           )}
         </div>


### PR DESCRIPTION
💡 What: Added an `aria-label` to the 'Clear search' icon button and hid the decorative `X` SVG icon from screen readers in `DirectorySearch.tsx`. Also added an entry to `.jules/palette.md` for learning.
🎯 Why: Without an `aria-label`, screen reader users have no context for what the 'X' button does.
📸 Before/After: N/A - Visual UI is unchanged, but DOM structure includes new attributes.
♿ Accessibility: Ensures that screen readers can effectively announce the button's purpose without redundantly announcing the SVG icon content.

---
*PR created automatically by Jules for task [7821180433978274464](https://jules.google.com/task/7821180433978274464) started by @carlsuburbmates*