### PR TITLE
docs: lock 3-user model and workflow/admin dashboard operating model

### DIFF
--- a/docs/ADMIN_DASHBOARD_SPEC.md
+++ b/docs/ADMIN_DASHBOARD_SPEC.md
@@ -1,0 +1,209 @@
+# SuburbMates — Admin Dashboard Spec
+
+> **Single-admin operations dashboard.**
+> This document replaces the old assumption that Supabase GUI alone is the operating surface.
+> Supabase remains the backend and emergency fallback. The primary operating surface after launch is one internal admin dashboard.
+
+---
+
+## 1) Why this exists
+SuburbMates is operated as a **one-admin business**.
+The admin dashboard must centralize:
+- tasks
+- exceptions
+- communications
+- monitoring
+- reviews
+- manual approvals
+- notifications
+
+The goal is not to expose every database table.
+The goal is to tell the admin exactly:
+- what needs attention now
+- what is due today
+- what is due this week
+- what is broken
+- what communication is required
+
+---
+
+## 2) Operating principle
+**Automate deterministic work. Surface exceptions.**
+
+The dashboard should not be a table editor.
+It should be a responsibility-first operating cockpit.
+
+---
+
+## 3) Required dashboard modules
+
+### 3.1 Dashboard home
+Must include:
+- urgent alerts
+- today's work queue
+- this week's work queue
+- pending claims
+- pending featured actions
+- pending communications
+- recent system failures / automation failures
+- quick actions
+
+### 3.2 Creators
+Must include:
+- all creators
+- seeded/unclaimed listings
+- claim requests
+- newly created listings
+- incomplete listings
+- duplicate candidates
+- inactive/suspended creators
+
+### 3.3 Listings & Products
+Must include:
+- active listings
+- products
+- broken product URLs
+- listings with no valid active products
+- missing metadata / incomplete fields
+- visibility issues
+
+### 3.4 Featured
+Must include:
+- active featured placements
+- expiring placements
+- pending featured requests
+- ineligible creators missing suburb/postcode
+- reminder status
+- featured history
+
+### 3.5 Communications
+Must include:
+- send email to one creator
+- send email to selected creators
+- email templates
+- message history
+- delivery status
+- failed sends / retry queue
+
+### 3.6 Inbox
+Must include:
+- contact submissions
+- creator support issues
+- claim disputes / escalations
+- unresolved inbox items
+
+### 3.7 Monitoring
+Must include:
+- outbound click trends
+- search trends
+- zero-result trends
+- redirect failures
+- automation failures
+- stale listings
+- integrity warnings
+
+### 3.8 Settings / operations
+Must include:
+- categories
+- region references
+- communication templates
+- admin notes
+- automation rules / toggles where appropriate
+
+---
+
+## 4) Notification system
+Notifications must be action-oriented, not vanity-oriented.
+
+### Notification classes
+#### Urgent
+Examples:
+- broken redirect spike
+- failed automation
+- claim conflict
+- featured placement issue
+
+#### Needs review
+Examples:
+- ambiguous duplicate
+- unclear ownership claim
+- incomplete featured application
+
+#### Due soon
+Examples:
+- featured expiry
+- unanswered creator response
+- incomplete onboarding
+
+#### Informational
+Examples:
+- claim approved
+- email sent
+- listing published
+- weekly digest ready
+
+### Notification delivery surfaces
+- in-dashboard notification center
+- admin email digest
+- optional urgent email alerts
+
+---
+
+## 5) Resend communication model
+Resend is the creator communication layer.
+
+### Required Resend use cases
+- claim approval
+- claim rejection / request for evidence
+- publish confirmation
+- incomplete profile nudge
+- broken link alert
+- featured reminder
+- featured expiry / renewal notice
+- manual admin outreach
+
+### Dashboard requirement
+The admin must be able to trigger communications from inside the dashboard without needing to operate external scripts or raw email tooling.
+
+---
+
+## 6) Daily and weekly admin jobs
+
+### Daily jobs
+- review urgent alerts
+- review claims
+- review broken/incomplete listings
+- review featured actions
+- review inbox
+- send required communications
+
+### Weekly jobs
+- review creators added / claimed / unresolved
+- review featured placements and upcoming expiries
+- review search gaps and zero-result patterns
+- review stale listings
+- review creators to contact
+- review unresolved system issues
+
+The dashboard should generate and surface these jobs automatically.
+
+---
+
+## 7) Hard requirements
+- one internal admin dashboard is required after launch
+- admin must not rely on Supabase dashboard as the primary daily operating surface
+- deterministic tasks should be automated
+- exceptions should be surfaced clearly
+- communications should be centralized and logged
+- all workflows should be manageable by a single admin without hunting across multiple tools
+
+---
+
+## 8) What this does NOT mean
+This does not mean:
+- building a bloated enterprise admin suite
+- exposing every raw DB table to the admin
+- replacing Supabase as backend infrastructure
+
+It means:
+- building the **minimum serious operating cockpit** needed to run SuburbMates as a one-admin business

--- a/docs/USER_MODEL.md
+++ b/docs/USER_MODEL.md
@@ -1,0 +1,88 @@
+# SuburbMates — User Model
+
+> **Authoritative product user model.**
+> This document overrides any conflicting user-type language in older docs until the legacy docs are fully reconciled.
+>
+> In product terms, SuburbMates has **3 user types only**:
+> 1. **Visitor**
+> 2. **Creator**
+> 3. **Admin**
+
+---
+
+## 1) Visitor
+A visitor is a public, unauthenticated user who uses the directory to discover creators and click through to external products.
+
+### Visitor can:
+- browse by category
+- browse by region
+- search creators
+- open creator profiles
+- click out to external product/store pages via `/api/redirect`
+- submit contact/support forms
+
+### Visitor cannot:
+- check out inside SuburbMates
+- manage creator content
+- access admin operations
+
+---
+
+## 2) Creator
+A creator is the owner/operator of a digital creator business listed in the directory.
+
+### Creator can:
+- authenticate with Magic Link / OTP or approved OAuth
+- search the directory first to see if their business is already listed
+- **claim an existing seeded listing**
+- **create a new listing** if no listing exists
+- manage their profile/business details
+- manage their products / drops
+- become eligible for featured placement by providing required location data
+- request featured placement
+- receive system and admin communications
+
+### Important note
+A **seeded but unclaimed listing is not a fourth user type**.
+It is a **listing state** that still belongs under the Creator model.
+
+---
+
+## 3) Admin
+An admin is the internal operator who runs the business.
+
+### Admin can:
+- seed and manage listings
+- review and approve claims
+- manage listing/profile visibility
+- manage featured placements
+- monitor operational health
+- handle creator communications
+- handle contact/support inboxes
+- review automations, exceptions, and tasks
+
+### Important note
+SuburbMates is currently a **one-admin business**.
+The product should optimize for a **single admin control dashboard**, not a multi-team back office.
+
+---
+
+## Technical naming vs product naming
+Product language must stay clean:
+- **Visitor**
+- **Creator**
+- **Admin**
+
+Technical/database naming may still include:
+- `users.user_type = 'customer' | 'business_owner' | 'admin'`
+- `vendors` table as the operational compatibility table
+
+These are implementation details and must not drive public product copy.
+
+---
+
+## Design rule
+All future docs, copy, flows, and UI decisions should assume:
+- **3 user types only**
+- no extra public-facing role labels
+- no public use of `vendor`, `customer`, or `business_owner` unless discussing raw database structures

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,0 +1,241 @@
+# SuburbMates — Workflows
+
+> **Authoritative workflow model.**
+> This document defines workflows by the locked 3-user model: Visitor, Creator, Admin.
+> It also overrides any older workflow language that assumes Supabase GUI alone is the primary operational surface.
+
+---
+
+# A. Visitor workflows
+
+## A1. Browse discovery
+1. Land on homepage
+2. Browse by category first
+3. Optionally narrow by region
+4. Open creator profile
+
+## A2. Search discovery
+1. Use global search
+2. Review matching creator results
+3. Open creator profile
+
+## A3. Product exit flow
+1. Open creator profile
+2. Tap product card
+3. Route through `/api/redirect`
+4. Log outbound click
+5. Redirect to creator's external page/store
+
+## A4. Contact/support flow
+1. Submit contact form
+2. Admin receives the submission in the admin inbox
+3. Admin replies when needed
+
+### Visitor automation requirements
+- search logging
+- outbound click logging
+- zero-result search aggregation
+- broken redirect detection
+- contact form ingestion into admin inbox
+
+---
+
+# B. Creator workflows
+
+## Core decision rule
+Every creator entry flow must begin with this instruction:
+
+> **Search the directory first. Your business may already be listed and waiting to be claimed.**
+
+That means creators always face two possible paths:
+1. **Claim existing listing**
+2. **Create new listing**
+
+---
+
+## B1. Authenticate
+1. Sign in via Magic Link / OTP or approved OAuth
+2. Enter creator-side flow
+
+**Password-first auth is banned.**
+
+## B2. Search-first decision
+1. Search for business/creator name
+2. If listing exists → go to claim workflow
+3. If listing does not exist → go to create workflow
+
+## B3. Claim existing listing
+1. Creator identifies the correct listing
+2. Creator submits claim request / proof
+3. System records claim request
+4. Admin reviews only if needed
+5. On approval, listing is attached to the creator account
+6. Confirmation email is sent via Resend
+
+### Claim automation requirements
+- claim intake form
+- claim queue state
+- claim status updates
+- creator confirmation / follow-up emails via Resend
+- duplicate-detection support for admin
+
+## B4. Create new listing
+1. Authenticate
+2. Paste URL or supply business details
+3. Run metadata scrape/fetch where possible
+4. Review/edit profile details
+5. Assign category
+6. Save/publish listing according to visibility rules
+
+## B5. Manage profile
+1. Update business/profile details
+2. Update category
+3. Update socials/website/contact fields
+4. Update location fields needed for featured eligibility
+5. Keep listing complete and publishable
+
+## B6. Manage products
+1. Add/edit/remove product drops
+2. Ensure `product_url` is valid
+3. Ensure product is active and not archived
+4. Maintain images and product metadata
+
+## B7. Featured eligibility workflow
+1. Creator expresses interest in featured placement
+2. System checks whether the creator has at minimum:
+   - suburb
+   - postcode
+3. If missing, the creator is prompted to complete those fields
+4. Once suburb + postcode are present, the platform maps the creator to a region
+5. Only then can the creator proceed to featured request / featured ops
+
+### Rule
+- **No valid region = no featured eligibility**
+- region assignment is automatic once required location data is present
+
+## B8. Featured request workflow
+1. Creator requests featured placement
+2. System creates a pending featured request state
+3. Admin reviews and activates manually
+4. Creator receives operational communications via Resend
+
+## B9. Creator communications workflow
+Creators may receive:
+- claim approval / rejection / request for more info
+- listing published / listing needs changes
+- featured approved / featured expiring / featured expired
+- broken link or incomplete profile notices
+- admin outreach when needed
+
+### Creator automation requirements
+- transactional email templates via Resend
+- reminders for incomplete listings
+- reminders for featured expiry
+- notifications for claim outcomes
+
+---
+
+# C. Admin workflows
+
+## Admin operating principle
+SuburbMates is a **one-admin business**.
+The admin should work from **one control dashboard**, not by juggling Supabase tables, scripts, and scattered operational memory.
+
+The dashboard must answer:
+- what needs attention now?
+- what is due today?
+- what is due this week?
+- what is broken?
+- who needs a communication?
+- what can be automated?
+
+## C1. Daily triage workflow
+1. Open admin dashboard home
+2. Review urgent alerts
+3. Review today's tasks
+4. Review pending claims
+5. Review broken/incomplete listings
+6. Review featured items needing action
+7. Review communications needing send/reply
+
+## C2. Listing operations workflow
+1. Review seeded/unclaimed listings
+2. Review newly created listings
+3. Review duplicate candidates
+4. Review incomplete listings
+5. Activate/deactivate visibility when needed
+
+## C3. Claim management workflow
+1. Review incoming claims
+2. Compare against existing listing/account evidence
+3. Approve / reject / request more information
+4. Trigger follow-up email via Resend
+
+## C4. Featured operations workflow
+1. Review active featured placements
+2. Review pending featured requests
+3. Review ineligible creators missing suburb/postcode
+4. Review expiring placements
+5. Activate/cancel/expire placements manually
+6. Trigger reminders and renewal emails via Resend
+
+## C5. Communications workflow
+1. Open communications center
+2. Send templated email to one creator or multiple creators
+3. Review send history and failures
+4. Retry failed sends when needed
+
+## C6. Contact/support workflow
+1. Review contact submissions
+2. Review creator support requests
+3. Reply or action issues
+4. Track unresolved items
+
+## C7. Monitoring workflow
+1. Review outbound clicks
+2. Review search trends and zero-result trends
+3. Review redirect failures / automation failures
+4. Review data-integrity issues (broken links, incomplete required fields)
+
+## C8. Weekly operations workflow
+1. Review creators added / claimed / unresolved
+2. Review featured placements sold / expiring / expired
+3. Review listings needing cleanup
+4. Review top categories / search gaps
+5. Review creators needing outreach
+6. Review any unresolved system issues
+
+---
+
+# D. Automation policy
+
+## Automate fully when deterministic
+Automate:
+- redirect logging
+- search logging
+- claim acknowledgements
+- publish confirmations
+- incomplete-profile reminders
+- featured reminders
+- expiring featured notices
+- broken-link checks
+- daily/weekly task generation
+- dashboard alert generation
+
+## Route exceptions to admin
+Do not attempt to fully automate:
+- ownership conflicts
+- ambiguous duplicate merges
+- suspicious claims
+- incomplete featured eligibility with unclear data
+- sensitive creator support cases
+
+---
+
+# E. Product rules locked by workflow model
+- Product has **3 user types only**: Visitor, Creator, Admin
+- Suburb is hidden/internal, except where needed for admin operations and featured eligibility
+- Creator onboarding must be **search-first**
+- Claim existing listing is preferred over creating duplicates
+- Admin work must be centralized into one internal operations dashboard
+- Resend is the email layer for creator communications and admin-triggered messaging


### PR DESCRIPTION
## Why
The product model has now been clarified and needs to be made explicit in the repo so Replit stops inferring user/workflow logic from scattered chat context.

## What this PR does
- adds `docs/USER_MODEL.md`
- adds `docs/WORKFLOWS.md`
- adds `docs/ADMIN_DASHBOARD_SPEC.md`

## Locked decisions in this PR
### User model
SuburbMates has **3 product user types only**:
1. Visitor
2. Creator
3. Admin

Seeded/unclaimed listings are a **listing state**, not a fourth user type.

### Workflow model
- creator entry must be **search-first**
- creator then either **claims an existing listing** or **creates a new one**
- featured eligibility requires enough location data to map to a valid region
- creator communications are part of the workflow model and should run through Resend

### Admin operations model
This PR intentionally overrides the older assumption that Supabase GUI alone is the admin operating surface.
After launch, the product should use **one internal admin dashboard** as the primary control center for the one-admin business.

That dashboard must centralize:
- task queues
- alerts
- claims
- featured ops
- creator communications
- inbox/support
- monitoring
- automations and failures

## Important note
These docs are intended to act as the authoritative workflow/user-model source until older docs like `SSOT_V2.1.md` and `UX_SPEC.md` are fully reconciled.

## Suggested next Replit task after this PR
1. reconcile conflicting passages in `docs/SSOT_V2.1.md`
2. reconcile workflow language in `docs/UX_SPEC.md`
3. identify any code or route assumptions that still depend on the old no-admin-UI model
4. create the first implementation brief for the admin dashboard from `docs/ADMIN_DASHBOARD_SPEC.md`
